### PR TITLE
Fix dialog outside test

### DIFF
--- a/.changeset/clean-birds-carry.md
+++ b/.changeset/clean-birds-carry.md
@@ -1,0 +1,5 @@
+---
+"@nais/ds-svelte-community": patch
+---
+
+Fix bug in checking if clicks are outside dialog.

--- a/packages/ds-svelte-community/src/lib/components/Modal/Modal.svelte
+++ b/packages/ds-svelte-community/src/lib/components/Modal/Modal.svelte
@@ -84,8 +84,9 @@
 			restProps.onclose(e);
 		}
 	}}
-	onclick={(e) => {
-		if (e.target === dialog) {
+	onclick={({ clientX, clientY }) => {
+		const { left, right, top, bottom } = dialog.getBoundingClientRect();
+		if (clientX < left || clientX > right || clientY < top || clientY > bottom) {
 			dialog.close();
 		}
 	}}


### PR DESCRIPTION
Buggen kan trigges ved å markere tekst i modalen som begynner i header og slutter i innholdet.