### PR TITLE
Selecting an indeterminate checkbox checks all child items

### DIFF
--- a/.changeset/lemon-jeans-pull.md
+++ b/.changeset/lemon-jeans-pull.md
@@ -1,0 +1,5 @@
+---
+"@nais/ds-svelte-community": minor
+---
+
+Selecting an indeterminate checkbox checks all child items

--- a/packages/ds-svelte-community/src/lib/components/ActionMenu/ActionMenuCheckboxItem.svelte
+++ b/packages/ds-svelte-community/src/lib/components/ActionMenu/ActionMenuCheckboxItem.svelte
@@ -30,7 +30,7 @@
 	data-index="0"
 	style="user-select: none;"
 	onclick={() => {
-		checked = checked === "indeterminate" ? false : !checked;
+		checked = checked === "indeterminate" ? true : !checked;
 		onchange?.(checked);
 	}}
 >

--- a/packages/ds-svelte-community/src/routes/components/ActionMenu/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/components/ActionMenu/+page.svelte
@@ -236,6 +236,13 @@
 							: Object.values(views).some(Boolean)
 								? "indeterminate"
 								: false}
+						onchange={(checked) => {
+							views = {
+								started: checked,
+								fnr: checked,
+								tags: checked,
+							};
+						}}
 					>
 						Select all
 					</ActionMenuCheckboxItem>


### PR DESCRIPTION
Det er sånn det funker i Aksel.

Ref. https://github.com/navikt/aksel/pull/3549