### PR TITLE
chore: align with Aksel v8.6.0 and tidy parity/docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,111 @@
+# AGENT.md
+
+## Project Snapshot
+
+This monorepo contains two packages:
+
+- `@nais/ds-svelte-community`: Svelte component library + docs/showcase app
+- `@nais/vite-plugin-svelte-docs`: Vite plugin for generating docs metadata from Svelte components
+
+Primary objective: keep Svelte components aligned with Aksel behavior and API, especially `@navikt/ds-react`, `@navikt/ds-css`, `@navikt/ds-tokens`, `@navikt/ds-tailwind`, and `@navikt/aksel-icons`, while preserving Svelte-friendly ergonomics.
+
+Reference roles:
+
+- Primary component/API parity reference: `@navikt/ds-react`
+- Styling/token foundations: `@navikt/ds-css`, `@navikt/ds-tokens`, `@navikt/ds-tailwind`
+- Icon source/reference: `@navikt/aksel-icons`
+
+Official references:
+
+- Aksel docs: https://aksel.nav.no/
+- Aksel source repository: https://github.com/navikt/aksel
+- Aksel v8 changelog: https://aksel.nav.no/grunnleggende/endringslogg/versjon-8
+- Aksel core components index: https://aksel.nav.no/komponenter/core
+- Aksel primitives index: https://aksel.nav.no/komponenter/primitives
+
+## Tech & Structure
+
+- Tooling: Bun workspaces, SvelteKit, Vite, TypeScript, ESLint, Prettier, Changesets
+- Main library source: `packages/ds-svelte-community/src/lib/**`
+- Showcase/docs app: `packages/ds-svelte-community/src/routes/**`
+- Tests + parity helpers: `packages/ds-svelte-community/src/tests/**` and `packages/ds-svelte-community/src/testlib/**`
+- Generated icons pipeline: `packages/ds-svelte-community/src/icons/generate.ts` -> `src/lib/icons/**`
+
+## Working Principles
+
+- Prefer root-cause fixes over temporary workarounds.
+- Keep changes small and consistent with existing patterns.
+- Do not change package scripts unless explicitly requested.
+- Avoid broad refactors unless they are required for the task.
+
+## Component Parity Expectations
+
+- When modifying/adding components, preserve HTML/behavior parity with `@navikt/ds-react` where intended.
+- Add or update parity tests when component behavior changes.
+- Use visual checks when needed for regressions:
+  - `VISUAL_TESTS=true bun run --filter @nais/ds-svelte-community test`
+- Out of scope for parity backlog: joke/demo-only entries in Aksel docs (e.g. `Navpoleonskake`).
+
+## Validation Workflow
+
+For normal library changes, run:
+
+1. `bun run --filter @nais/ds-svelte-community check`
+2. `bun run --filter @nais/ds-svelte-community test:unit`
+3. `bun run --filter @nais/ds-svelte-community check-peer-deps`
+4. `bun run --filter @nais/ds-svelte-community lint`
+
+For repo-wide checks:
+
+- `bun run check`
+- `bun run test`
+
+## Dependency Alignment
+
+- Keep these on the same Aksel minor where possible:
+  - `@navikt/ds-css`
+  - `@navikt/ds-tokens`
+  - `@navikt/ds-react`
+  - `@navikt/ds-tailwind`
+  - `@navikt/aksel-icons`
+
+## Quick Diff Workflow (After a Break)
+
+Use this checklist to quickly assess parity status:
+
+1. Confirm installed Aksel versions:
+
+- `bun pm view @navikt/ds-react version`
+- `bun pm view @navikt/ds-css version`
+- `bun pm view @navikt/ds-tokens version`
+
+2. Compare implemented Svelte components:
+
+- `packages/ds-svelte-community/src/lib/index.ts`
+- `packages/ds-svelte-community/src/lib/components/**`
+
+3. Compare against Aksel indexes:
+
+- Core: https://aksel.nav.no/komponenter/core
+- Primitives: https://aksel.nav.no/komponenter/primitives
+
+4. Validate current health:
+
+- `bun run --filter @nais/ds-svelte-community check`
+- `bun run --filter @nais/ds-svelte-community test:unit`
+- `bun run --filter @nais/ds-svelte-community check-peer-deps`
+
+5. For parity-sensitive changes, run optional visual tests:
+
+- `VISUAL_TESTS=true bun run --filter @nais/ds-svelte-community test`
+
+## Release Notes
+
+- Versioning and changelogs are managed with Changesets.
+- Typical release flow from root:
+  - `bun run build`
+  - `bun run release`
+
+## Troubleshooting Note (Generated Artifacts)
+
+If diagnostics look unusually noisy, first confirm whether errors originate from generated/build output (`storybook-static`, `dist`, `.svelte-kit`) versus source files. Treat generated output as artifacts unless task scope explicitly includes regenerating or validating them.

--- a/bun.lock
+++ b/bun.lock
@@ -27,11 +27,11 @@
       "version": "2.0.0-next.6",
       "devDependencies": {
         "@nais/vite-plugin-svelte-docs": "workspace:*",
-        "@navikt/aksel-icons": "^8.4.1",
-        "@navikt/ds-css": "8.4.1",
-        "@navikt/ds-react": "^8.4.1",
-        "@navikt/ds-tailwind": "^8.4.1",
-        "@navikt/ds-tokens": "8.4.1",
+        "@navikt/aksel-icons": "^8.6.0",
+        "@navikt/ds-css": "8.6.0",
+        "@navikt/ds-react": "^8.6.0",
+        "@navikt/ds-tailwind": "^8.6.0",
+        "@navikt/ds-tokens": "8.6.0",
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.52.0",
         "@sveltejs/package": "^2.5.7",
@@ -78,8 +78,8 @@
         "svelte-floating-ui": "^1.6.2",
       },
       "peerDependencies": {
-        "@navikt/ds-css": "8.4.1",
-        "@navikt/ds-tokens": "8.4.1",
+        "@navikt/ds-css": "8.6.0",
+        "@navikt/ds-tokens": "8.6.0",
         "svelte": "^5.20.0",
       },
     },
@@ -291,15 +291,15 @@
 
     "@nais/vite-plugin-svelte-docs": ["@nais/vite-plugin-svelte-docs@workspace:packages/vite-plugin-svelte-docs"],
 
-    "@navikt/aksel-icons": ["@navikt/aksel-icons@8.4.1", "", {}, "sha512-NF1hXW7fmInZ9sT/Ld7e7UE7XaTIidgo/Mamf4Wpm1JlJoyi0vukKIXN9M4ULRw7nSmAz481I5+uJtMIRatCHA=="],
+    "@navikt/aksel-icons": ["@navikt/aksel-icons@8.6.0", "", {}, "sha512-e+evlFA6eq7vW1pZDg1Fc9V7L7h/Mp1Luubv7kTJUp4IrWQN7Is+nfVj65TLcrQqMm9fjkmc1eI5PcmuY9ibvQ=="],
 
-    "@navikt/ds-css": ["@navikt/ds-css@8.4.1", "", {}, "sha512-VgsP5KSTEc6d8yRcBu4n2xacwt4iA45cpui5VSBmboQ5TZj87gttg3Vz+Dqq0anhiZqFDTwP5qhrsJhoauoZGA=="],
+    "@navikt/ds-css": ["@navikt/ds-css@8.6.0", "", {}, "sha512-Rv39j5USosDDcOlcfNUG9uVOJ+ZgMjEvVRQdAN0QTVY3rBpceNlMbrBQEo1YzDlA6WpD9d8DyiGuDYYVpakoLw=="],
 
-    "@navikt/ds-react": ["@navikt/ds-react@8.4.1", "", { "dependencies": { "@floating-ui/react": "0.27.8", "@floating-ui/react-dom": "^2.1.6", "@navikt/aksel-icons": "^8.4.1", "@navikt/ds-tokens": "^8.4.1", "date-fns": "^4.0.0", "react-day-picker": "9.7.0" }, "peerDependencies": { "@types/react": "^17.0.30 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-QMHjwlEzYHgE6tab69uvrs1HZmctB8IWUe9rYcMVrB5ePGed5cRT6Hj/3DOQVbXt6K/m8u+71cK/mjI2cLiG0Q=="],
+    "@navikt/ds-react": ["@navikt/ds-react@8.6.0", "", { "dependencies": { "@floating-ui/react": "0.27.8", "@floating-ui/react-dom": "^2.1.6", "@navikt/aksel-icons": "^8.6.0", "@navikt/ds-tokens": "^8.6.0", "date-fns": "^4.0.0", "react-day-picker": "9.7.0" }, "peerDependencies": { "@types/react": "^17.0.30 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-yAZAZT+Ii9exJFbxqVy1ONjJvb1k+iKH8KoIFgroPHS6k+QhiBnB52aas1LSoWR7eqHpgUNV6QMUsQt24kmT3A=="],
 
-    "@navikt/ds-tailwind": ["@navikt/ds-tailwind@8.4.1", "", {}, "sha512-2t3Tll7pT6n2ARJK1z1ShlkchFIMlsRoSJ5pHTOloUqh5Sd4t/u/h8a7TvZBy1gEjzM7QHskDm9rc7cDL0Hoxw=="],
+    "@navikt/ds-tailwind": ["@navikt/ds-tailwind@8.6.0", "", {}, "sha512-+Juw/m7bH6ZkfF7EYZX6/bQMjBAsbJ/GbQbmhoLCSMiSmA1c8U6ImLQBxjDijFsLO4DvVYPgTY/cAiAaF3YR7w=="],
 
-    "@navikt/ds-tokens": ["@navikt/ds-tokens@8.4.1", "", {}, "sha512-MafU7Om2zj5sn7uL5P57EAeV0n6/duU1IKuBW0ghUZE47A/cRJS/oG+PQTwg3FYBgXKkpInsx70k0oL+D7NR5A=="],
+    "@navikt/ds-tokens": ["@navikt/ds-tokens@8.6.0", "", {}, "sha512-MdnPFvi7wPF0N5ms6psNqW0IevlHhoswUCOYFQl7hFwL+uRcqFna6rT8fm/co04z/HDUKKfadbrW0yodzDxj1w=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/packages/ds-svelte-community/package.json
+++ b/packages/ds-svelte-community/package.json
@@ -61,20 +61,20 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"@navikt/ds-css": "8.4.1",
-		"@navikt/ds-tokens": "8.4.1",
+		"@navikt/ds-css": "8.6.0",
+		"@navikt/ds-tokens": "8.6.0",
 		"svelte": "^5.20.0"
 	},
 	"optionalDependencies": {
 		"svelte-floating-ui": "^1.6.2"
 	},
 	"devDependencies": {
-		"@navikt/ds-css": "8.4.1",
-		"@navikt/ds-tokens": "8.4.1",
+		"@navikt/ds-css": "8.6.0",
+		"@navikt/ds-tokens": "8.6.0",
 		"@nais/vite-plugin-svelte-docs": "workspace:*",
-		"@navikt/aksel-icons": "^8.4.1",
-		"@navikt/ds-react": "^8.4.1",
-		"@navikt/ds-tailwind": "^8.4.1",
+		"@navikt/aksel-icons": "^8.6.0",
+		"@navikt/ds-react": "^8.6.0",
+		"@navikt/ds-tailwind": "^8.6.0",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.52.0",
 		"@sveltejs/package": "^2.5.7",

--- a/packages/ds-svelte-community/src/doclib/Renderer.svelte
+++ b/packages/ds-svelte-community/src/doclib/Renderer.svelte
@@ -236,9 +236,6 @@
 		position: relative;
 
 		.copy-code {
-			--ac-copybutton-neutral-text: var(--ax-text-default);
-			--ac-copybutton-neutral-hover-text: var(--ax-text-meta-purple);
-			--ac-copybutton-neutral-active-text: var(--ax-text-meta-purple-strong);
 			display: none;
 
 			position: absolute;
@@ -248,6 +245,18 @@
 
 		&:hover .copy-code {
 			display: block;
+		}
+
+		.copy-code :global(.aksel-copybutton) {
+			color: var(--ax-text-default);
+		}
+
+		.copy-code :global(.aksel-copybutton:hover) {
+			color: var(--ax-text-meta-purple);
+		}
+
+		.copy-code :global(.aksel-copybutton:active) {
+			color: var(--ax-text-meta-purple-strong);
 		}
 
 		& :global(pre) {

--- a/packages/ds-svelte-community/src/lib/components/primitives/Box/box.test.ts
+++ b/packages/ds-svelte-community/src/lib/components/primitives/Box/box.test.ts
@@ -16,7 +16,7 @@ describe("Box", () => {
 			})),
 		};
 
-		expect(render(Box, props)).toMimicReact(ReactBox.New, {
+		expect(render(Box, props)).toMimicReact(ReactBox, {
 			props,
 			children: [React.createElement("span", {}, "Box body")],
 		});
@@ -39,7 +39,7 @@ describe("Box", () => {
 			})),
 		};
 
-		expect(render(Box, props)).toMimicReact(ReactBox.New, {
+		expect(render(Box, props)).toMimicReact(ReactBox, {
 			props,
 			children: [React.createElement("span", {}, "Box body")],
 		});

--- a/packages/ds-svelte-community/src/tests/component_done.test.ts
+++ b/packages/ds-svelte-community/src/tests/component_done.test.ts
@@ -22,7 +22,6 @@ describe("which components are implemented", () => {
 		"ActionMenuSubContent",
 		"ActionMenuSubTrigger",
 		"ActionMenuTrigger",
-		"BoxNew",
 		"DatePicker",
 		"DatePickerInput",
 		"DatePickerStandalone",
@@ -94,6 +93,7 @@ describe("which components are implemented", () => {
 		"LinkPanelDescription", // @deprecated Use LinkCard instead
 		"LinkPanelTitle", // @deprecated Use LinkCard instead
 		"Ingress", // @deprecated Use BodyLong size="large" instead
+		"BoxNew", // @deprecated Use Box instead
 	];
 
 	const reactComponents = Object.keys(allReact).filter(


### PR DESCRIPTION
## Summary
This PR improves maintainability and aligns the Svelte library with current Aksel v8.6.0 behavior.

## What changed
- Added AGENT.md with project conventions, parity expectations, validation workflow, dependency alignment, and troubleshooting guidance.
- Updated Aksel dependencies to 8.6.0 in packages/ds-svelte-community/package.json (peer and dev), with lockfile updates in bun.lock.
- Updated Box parity tests to use current React API (ReactBox instead of ReactBox.New).
- Clarified deprecated component tracking by moving BoxNew to ignored/deprecated.
- Reworked copy-button preview styling in doclib Renderer to explicit token-based selectors, avoiding legacy component-token overrides.

## Validation
- bun run --filter @nais/ds-svelte-community check
- bun run --filter @nais/ds-svelte-community test:unit
- bun run --filter @nais/ds-svelte-community check-peer-deps

## Follow-up scope
- Start parity implementation backlog with Combobox.
- Continue with DatePicker and MonthPicker after shared interaction patterns are established.
