### PR TITLE
docs: add pages and examples for existing components, primitives, and…

### DIFF
--- a/.changeset/docs-pages-parity.md
+++ b/.changeset/docs-pages-parity.md
@@ -1,0 +1,5 @@
+---
+"@nais/ds-svelte-community": patch
+---
+
+Add documentation pages and examples for existing components, primitives, and typography to achieve parity with Aksel: Fieldset, Theme, HGrid, Page, Hide, Show, Stack, HStack, VStack, Heading, Label, ErrorMessage, and Link.

--- a/packages/ds-svelte-community/.gitignore
+++ b/packages/ds-svelte-community/.gitignore
@@ -9,7 +9,6 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
-/storybook-static
 /src/testlib/*.d.ts
 !/src/testlib/ambient.d.ts
 .vscode

--- a/packages/ds-svelte-community/.prettierignore
+++ b/packages/ds-svelte-community/.prettierignore
@@ -1,0 +1,6 @@
+CHANGELOG.md
+node_modules
+/build
+/dist
+/.svelte-kit
+/package

--- a/packages/ds-svelte-community/src/routes/components/Fieldset/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/components/Fieldset/+page.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import doc from "$lib/components/Fieldset/Fieldset.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { BodyLong, Fieldset, Heading, HStack, Select, Switch, TextField, VStack } from "$lib";
+</script>
+
+<Doc {doc}>
+	<Story>
+		<Fieldset legend="When do you want to retire?">
+			<HStack gap="space-16">
+				<Select label="Select year">
+					<option></option>
+					<option>62 years</option>
+					<option>63 years</option>
+					<option>64 years</option>
+					<option>...</option>
+				</Select>
+				<Select label="Select month">
+					<option></option>
+					<option>0 mo. (Apr)</option>
+					<option>1 mo. (May)</option>
+					<option>2 mo. (Jun)</option>
+					<option>...</option>
+				</Select>
+			</HStack>
+		</Fieldset>
+	</Story>
+
+	<Story name="Phone number">
+		<Fieldset legend="Employer's phone number">
+			<HStack gap="space-16">
+				<Select label="Country code">
+					<option></option>
+					<option>+45</option>
+					<option>+46</option>
+					<option>+47</option>
+					<option>...</option>
+				</Select>
+				<TextField label="Number" htmlSize={8} />
+			</HStack>
+		</Fieldset>
+	</Story>
+
+	<Story name="Switch group">
+		<Fieldset legend="How would you like to be notified?">
+			<div>
+				<Switch>Email</Switch>
+				<Switch>SMS</Switch>
+				<Switch>Push notification in the app</Switch>
+				<Switch>Smoke signal</Switch>
+			</div>
+		</Fieldset>
+	</Story>
+
+	<Story name="Address">
+		<VStack gap="space-36">
+			<Fieldset>
+				{#snippet legend()}
+					<Heading as="span" size="small">Private address</Heading>
+				{/snippet}
+				<TextField label="Street" />
+				<TextField label="Postal code" htmlSize={8} />
+				<TextField label="City" />
+				<TextField label="Country" style="max-width: 300px" />
+			</Fieldset>
+
+			<Fieldset>
+				{#snippet legend()}
+					<Heading as="span" size="small">Employer's address</Heading>
+				{/snippet}
+				<TextField label="Street" />
+				<TextField label="Postal code" htmlSize={8} />
+				<TextField label="City" />
+				<TextField label="Country" style="max-width: 300px" />
+			</Fieldset>
+		</VStack>
+	</Story>
+
+	<Story name="Heading as legend">
+		<Fieldset>
+			{#snippet legend()}
+				<Heading level="2" size="medium">Employer's address</Heading>
+			{/snippet}
+			<TextField label="Street" />
+			<TextField label="Postal code" htmlSize={8} />
+			<TextField label="City" />
+			<TextField label="Country" style="max-width: 300px" />
+		</Fieldset>
+	</Story>
+
+	<Story name="Hide legend">
+		<Heading size="medium" spacing>Employer's address</Heading>
+		<BodyLong spacing>
+			Lorem ipsum dolor sit, amet consectetur adipisicing elit. Tempora sunt commodi corporis
+			voluptatibus, maiores laborum, repellat nam labore.
+		</BodyLong>
+		<Fieldset legend="Employer's address" hideLegend>
+			<TextField label="Street" />
+			<TextField label="Postal code" htmlSize={8} />
+			<TextField label="City" />
+			<TextField label="Country" style="max-width: 300px" />
+		</Fieldset>
+	</Story>
+
+	<Story name="With error">
+		<Fieldset legend="When do you want to retire?" error="You must fill in all fields.">
+			<HStack gap="space-16">
+				<Select label="Select year">
+					<option></option>
+					<option>62 years</option>
+					<option>63 years</option>
+					<option>64 years</option>
+				</Select>
+				<Select label="Select month">
+					<option></option>
+					<option>0 mo. (Apr)</option>
+					<option>1 mo. (May)</option>
+					<option>2 mo. (Jun)</option>
+				</Select>
+			</HStack>
+		</Fieldset>
+	</Story>
+
+	<Story name="Size small">
+		<Fieldset legend="When do you want to retire?" size="small">
+			<HStack gap="space-16">
+				<Select label="Select year" size="small">
+					<option></option>
+					<option>62 years</option>
+					<option>63 years</option>
+				</Select>
+				<Select label="Select month" size="small">
+					<option></option>
+					<option>0 mo. (Apr)</option>
+					<option>1 mo. (May)</option>
+				</Select>
+			</HStack>
+		</Fieldset>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/components/Theme/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/components/Theme/+page.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import doc from "$lib/components/Theme/Theme.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { Alert, BodyLong, Box, Button, Heading, Tag, Theme, VStack } from "$lib";
+</script>
+
+<Doc {doc}>
+	<Story>
+		<Theme>
+			<Box padding="space-24">
+				<Heading level="2" size="medium" spacing>Default theme</Heading>
+				<BodyLong spacing>
+					Theme provides design tokens and background/foreground colors to its children. By default
+					it uses the light theme.
+				</BodyLong>
+				<Button>Primary button</Button>
+			</Box>
+		</Theme>
+	</Story>
+
+	<Story name="Dark">
+		<Theme theme="dark">
+			<Box padding="space-24">
+				<Heading level="2" size="medium" spacing>Dark theme</Heading>
+				<BodyLong spacing>
+					Use <code>theme="dark"</code> to render children with the dark theme.
+				</BodyLong>
+				<Button>Primary button</Button>
+			</Box>
+		</Theme>
+	</Story>
+
+	<Story name="Nested">
+		<Theme theme="light">
+			<Box padding="space-24">
+				<Heading level="2" size="medium" spacing>Light section</Heading>
+				<BodyLong spacing>
+					You can nest Theme components to mix light and dark sections on the same page.
+				</BodyLong>
+
+				<Theme theme="dark" as="section">
+					<Box padding="space-24">
+						<Heading level="3" size="small" spacing>Dark section</Heading>
+						<BodyLong spacing>
+							This section uses the dark theme, while the surrounding content stays light.
+						</BodyLong>
+						<Button>Primary button</Button>
+					</Box>
+				</Theme>
+			</Box>
+		</Theme>
+	</Story>
+
+	<Story name="Color roles">
+		<VStack gap="space-16">
+			<Theme data-color="accent">
+				<Box padding="space-16">
+					<Tag variant="neutral">accent</Tag>
+					<Button>Primary</Button>
+				</Box>
+			</Theme>
+			<Theme data-color="success">
+				<Box padding="space-16">
+					<Tag variant="neutral">success</Tag>
+					<Alert variant="success">Success color role</Alert>
+				</Box>
+			</Theme>
+			<Theme data-color="warning">
+				<Box padding="space-16">
+					<Tag variant="neutral">warning</Tag>
+					<Alert variant="warning">Warning color role</Alert>
+				</Box>
+			</Theme>
+			<Theme data-color="danger">
+				<Box padding="space-16">
+					<Tag variant="neutral">danger</Tag>
+					<Alert variant="error">Danger color role</Alert>
+				</Box>
+			</Theme>
+		</VStack>
+	</Story>
+
+	<Story name="Without background">
+		<Theme theme="dark" hasBackground={false}>
+			<Box padding="space-24">
+				<BodyLong>
+					With <code>hasBackground=&#123;false&#125;</code> the Theme element does not paint its own background.
+				</BodyLong>
+			</Box>
+		</Theme>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/primitives/HGrid/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/HGrid/+page.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import doc from "$lib/components/primitives/HGrid/HGrid.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { Box, HGrid } from "$lib";
+	import Placeholder from "./Placeholder.svelte";
+</script>
+
+<Doc {doc}>
+	<Story locked>
+		<Box background="neutral-moderate">
+			<HGrid gap="space-24" columns={3}>
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+			</HGrid>
+		</Box>
+	</Story>
+
+	<Story name="Columns variants" locked>
+		<Box background="neutral-moderate">
+			<HGrid gap="space-24" columns={{ xs: "repeat(auto-fit, minmax(10rem, 1fr))", md: 4 }}>
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+			</HGrid>
+		</Box>
+	</Story>
+
+	<Story name="Responsive columns" locked>
+		<Box background="neutral-moderate">
+			<HGrid gap="space-24" columns={{ xs: 1, sm: 2, md: 4 }}>
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+			</HGrid>
+		</Box>
+	</Story>
+
+	<Story name="Responsive gap" locked>
+		<Box background="neutral-moderate">
+			<HGrid gap={{ xs: "space-8", md: "space-32" }} columns={3}>
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+				<Placeholder height="15rem" />
+			</HGrid>
+		</Box>
+	</Story>
+
+	<Story name="Align" locked>
+		<HGrid gap="space-16" columns={2} align="start">
+			<Placeholder height="10rem">Start</Placeholder>
+			<Placeholder />
+		</HGrid>
+		<HGrid gap="space-16" columns={2} align="center">
+			<Placeholder height="10rem">Center</Placeholder>
+			<Placeholder />
+		</HGrid>
+		<HGrid gap="space-16" columns={2} align="end">
+			<Placeholder height="10rem">End</Placeholder>
+			<Placeholder />
+		</HGrid>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/primitives/HGrid/Placeholder.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/HGrid/Placeholder.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { Box } from "$lib";
+
+	let { height = "5rem", children }: { height?: string; children?: import("svelte").Snippet } =
+		$props();
+</script>
+
+<Box
+	background="neutral-strong"
+	{height}
+	style="display: grid; place-content: center; color: var(--ax-text-accent-contrast);"
+>
+	{#if children}
+		{@render children()}
+	{/if}
+</Box>

--- a/packages/ds-svelte-community/src/routes/primitives/HStack/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/HStack/+page.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+	import doc from "$lib/components/primitives/Stack/HStack.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { Box, Heading, HStack, Spacer, VStack } from "$lib";
+	import Placeholder from "./Placeholder.svelte";
+</script>
+
+<Doc {doc}>
+	<Story locked>
+		<HStack gap="space-16">
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+		</HStack>
+	</Story>
+
+	<Story name="Wrap" locked>
+		<Box maxWidth="385px" padding="space-8" background="neutral-moderate">
+			<VStack gap="space-12">
+				<div>
+					<Heading size="xsmall">wrap=true (default)</Heading>
+					<HStack gap="space-8">
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+					</HStack>
+				</div>
+
+				<div>
+					<Heading size="xsmall">wrap=false</Heading>
+					<HStack gap="space-8" wrap={false}>
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+						<Placeholder height="3rem" width="3rem" />
+					</HStack>
+				</div>
+			</VStack>
+		</Box>
+	</Story>
+
+	<Story name="Align" locked>
+		<VStack gap="space-48">
+			<HStack gap="space-12" align="center">
+				<Placeholder text="center" />
+				<Placeholder />
+				<Placeholder />
+				<Placeholder />
+			</HStack>
+			<HStack gap="space-12" align="end">
+				<Placeholder text="end" />
+				<Placeholder />
+				<Placeholder />
+				<Placeholder />
+			</HStack>
+			<HStack gap="space-12" align="start">
+				<Placeholder text="start" />
+				<Placeholder />
+				<Placeholder />
+				<Placeholder />
+			</HStack>
+			<HStack gap="space-12" align="stretch">
+				<Placeholder text="stretch" />
+				<Placeholder />
+				<Placeholder />
+				<Placeholder />
+			</HStack>
+		</VStack>
+	</Story>
+
+	<Story name="Justify" locked>
+		<Box background="neutral-moderate" width="18rem">
+			<VStack gap="space-48">
+				<HStack gap="space-12" justify="center">
+					<Placeholder text="center" />
+					<Placeholder />
+					<Placeholder />
+				</HStack>
+				<HStack gap="space-12" justify="end">
+					<Placeholder text="end" />
+					<Placeholder />
+					<Placeholder />
+				</HStack>
+				<HStack gap="space-12" justify="start">
+					<Placeholder text="start" />
+					<Placeholder />
+					<Placeholder />
+				</HStack>
+				<HStack gap="space-12" justify="space-around">
+					<Placeholder text="around" />
+					<Placeholder />
+					<Placeholder />
+				</HStack>
+				<HStack gap="space-12" justify="space-between">
+					<Placeholder text="between" />
+					<Placeholder />
+					<Placeholder />
+				</HStack>
+				<HStack gap="space-12" justify="space-evenly">
+					<Placeholder text="evenly" />
+					<Placeholder />
+					<Placeholder />
+				</HStack>
+			</VStack>
+		</Box>
+	</Story>
+
+	<Story name="Responsive gap" locked>
+		<HStack
+			gap={{
+				xs: "space-8",
+				sm: "space-24",
+				md: "space-40",
+				lg: "space-56",
+				xl: "space-72",
+			}}
+		>
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+		</HStack>
+	</Story>
+
+	<Story name="Spacer" locked>
+		<Box background="neutral-moderate">
+			<HStack gap="space-12" wrap={false}>
+				<Placeholder height="2rem" width="2rem" />
+				<Spacer />
+				<Placeholder height="2rem" width="2rem" />
+			</HStack>
+		</Box>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/primitives/HStack/Placeholder.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/HStack/Placeholder.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Box } from "$lib";
+	import type { SpacingScale } from "$lib/components/utils/types";
+
+	let {
+		text,
+		padding = "space-8",
+		height,
+		width,
+	}: {
+		text?: string;
+		padding?: SpacingScale;
+		height?: string;
+		width?: string;
+	} = $props();
+</script>
+
+<Box
+	background="neutral-strong"
+	borderRadius="4"
+	{padding}
+	{height}
+	{width}
+	style="color: var(--ax-text-accent-contrast);"
+>
+	{text ?? ""}
+</Box>

--- a/packages/ds-svelte-community/src/routes/primitives/Hide/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/Hide/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import doc from "$lib/components/primitives/Responsive/Hide.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { Box, HGrid, Hide } from "$lib";
+</script>
+
+<Doc {doc}>
+	<Story locked>
+		<HGrid columns={2} gap="space-16">
+			<Box padding="space-16" background="neutral-moderate">Always visible</Box>
+			<Hide below="md">
+				<Box padding="space-16" background="neutral-strong">I disappear on mobile (below md)</Box>
+			</Hide>
+		</HGrid>
+	</Story>
+
+	<Story name="Hide above" locked>
+		<HGrid columns={2} gap="space-16">
+			<Box padding="space-16" background="neutral-moderate">Always visible</Box>
+			<Hide above="md">
+				<Box padding="space-16" background="neutral-strong">I disappear on desktop (above md)</Box>
+			</Hide>
+		</HGrid>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/primitives/Page/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/Page/+page.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import doc from "$lib/components/primitives/Page/Page.svelte?doc";
+	import blockDoc from "$lib/components/primitives/Page/PageBlock.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { BodyLong, Box, Heading, Page, PageBlock, VStack } from "$lib";
+</script>
+
+<Doc {doc} extraChildrenDoc={[blockDoc]}>
+	<Story locked>
+		<Box background="neutral-moderate">
+			<Page>
+				<Box as="header" background="neutral-strong" padding="space-16">
+					<PageBlock width="xl" gutters>
+						<Heading level="1" size="medium">Header</Heading>
+					</PageBlock>
+				</Box>
+
+				<PageBlock as="main" width="xl" gutters>
+					<Box paddingBlock="space-32">
+						<Heading level="2" size="large" spacing>Page.Block</Heading>
+						<BodyLong>
+							Page wraps the full page layout, while Page.Block centers content and applies a max
+							width. Use Page.Block in headers and footers to keep content aligned with the main
+							content area.
+						</BodyLong>
+					</Box>
+				</PageBlock>
+
+				{#snippet footer()}
+					<Box as="footer" background="neutral-strong" padding="space-16">
+						<PageBlock width="xl" gutters>
+							<BodyLong>Footer</BodyLong>
+						</PageBlock>
+					</Box>
+				{/snippet}
+			</Page>
+		</Box>
+	</Story>
+
+	<Story name="Width" locked>
+		<Box background="neutral-moderate">
+			<Page>
+				<PageBlock as="main" width="text" gutters>
+					<Box paddingBlock="space-32">
+						<BodyLong>
+							We recommend using <code>width="text"</code> for blocks of text. This sets the max width
+							to 576px + padding and gives a comfortable line length.
+						</BodyLong>
+					</Box>
+				</PageBlock>
+			</Page>
+		</Box>
+	</Story>
+
+	<Story name="Widths" locked>
+		<VStack gap="space-16">
+			{#each ["text", "md", "lg", "xl", "2xl"] as const as width (width)}
+				<Box background="neutral-moderate">
+					<PageBlock {width} gutters>
+						<Box padding="space-16" background="neutral-strong">
+							<BodyLong>width="{width}"</BodyLong>
+						</Box>
+					</PageBlock>
+				</Box>
+			{/each}
+		</VStack>
+	</Story>
+
+	<Story name="Gutters" locked>
+		<VStack gap="space-16">
+			<Box background="neutral-moderate">
+				<PageBlock width="xl" gutters>
+					<Box padding="space-16" background="neutral-strong">
+						<BodyLong>Page.Block with gutters</BodyLong>
+					</Box>
+				</PageBlock>
+			</Box>
+			<Box background="neutral-moderate">
+				<PageBlock width="xl">
+					<Box padding="space-16" background="neutral-strong">
+						<BodyLong>Page.Block without gutters</BodyLong>
+					</Box>
+				</PageBlock>
+			</Box>
+		</VStack>
+	</Story>
+
+	<Story name="Footer below fold" locked>
+		<Box background="neutral-moderate" height="20rem" overflow="auto">
+			<Page footerPosition="belowFold">
+				<PageBlock as="main" width="xl" gutters>
+					<Box paddingBlock="space-32">
+						<Heading level="2" size="medium" spacing>Short content</Heading>
+						<BodyLong>
+							With <code>footerPosition="belowFold"</code> the footer is pushed below the fold, so short
+							content still fills the viewport.
+						</BodyLong>
+					</Box>
+				</PageBlock>
+
+				{#snippet footer()}
+					<Box as="footer" background="neutral-strong" padding="space-16">
+						<PageBlock width="xl" gutters>
+							<BodyLong>Footer below fold</BodyLong>
+						</PageBlock>
+					</Box>
+				{/snippet}
+			</Page>
+		</Box>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/primitives/Show/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/Show/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import doc from "$lib/components/primitives/Responsive/Show.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { Box, Show, VStack } from "$lib";
+</script>
+
+<Doc {doc}>
+	<Story locked>
+		<VStack gap="space-16">
+			<Show below="md">
+				<Box padding="space-16" background="neutral-strong">Visible only on mobile (below md)</Box>
+			</Show>
+			<Show above="md">
+				<Box padding="space-16" background="neutral-strong">Visible only on desktop (above md)</Box>
+			</Show>
+		</VStack>
+	</Story>
+
+	<Story name="Above" locked>
+		<Show above="md">
+			<Box padding="space-16" background="neutral-strong">I appear only on desktop (above md)</Box>
+		</Show>
+	</Story>
+
+	<Story name="Below" locked>
+		<Show below="md">
+			<Box padding="space-16" background="neutral-strong">I appear only on mobile (below md)</Box>
+		</Show>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/primitives/Stack/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/Stack/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import doc from "$lib/components/primitives/Stack/Stack.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { Stack } from "$lib";
+	import Placeholder from "../HStack/Placeholder.svelte";
+</script>
+
+<Doc {doc}>
+	<Story locked>
+		<Stack gap="space-16" direction="row">
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+		</Stack>
+	</Story>
+
+	<Story name="Column" locked>
+		<Stack gap="space-16" direction="column">
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+		</Stack>
+	</Story>
+
+	<Story name="Responsive direction" locked>
+		<Stack
+			gap="space-16"
+			direction={{ xs: "column", md: "row" }}
+			align={{ xs: "center", md: "start" }}
+		>
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="2rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="2rem" width="3rem" />
+		</Stack>
+	</Story>
+
+	<Story name="Responsive gap" locked>
+		<Stack
+			direction="row"
+			gap={{
+				xs: "space-8",
+				sm: "space-24",
+				md: "space-40",
+				lg: "space-56",
+				xl: "space-72",
+			}}
+		>
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+		</Stack>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/primitives/VStack/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/primitives/VStack/+page.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	import doc from "$lib/components/primitives/Stack/VStack.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { Box, HStack, VStack } from "$lib";
+	import Placeholder from "../HStack/Placeholder.svelte";
+</script>
+
+<Doc {doc}>
+	<Story locked>
+		<VStack gap="space-16">
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+		</VStack>
+	</Story>
+
+	<Story name="Align" locked>
+		<HStack gap="space-48">
+			<VStack gap="space-12" align="center">
+				<Placeholder text="center" />
+				<Placeholder />
+				<Placeholder />
+				<Placeholder />
+			</VStack>
+			<VStack gap="space-12" align="end">
+				<Placeholder text="end" />
+				<Placeholder />
+				<Placeholder />
+				<Placeholder />
+			</VStack>
+			<VStack gap="space-12" align="start">
+				<Placeholder text="start" />
+				<Placeholder />
+				<Placeholder />
+				<Placeholder />
+			</VStack>
+			<VStack gap="space-12" align="stretch">
+				<Placeholder text="stretch" />
+				<Placeholder />
+				<Placeholder />
+				<Placeholder />
+			</VStack>
+		</HStack>
+	</Story>
+
+	<Story name="Justify" locked>
+		<Box style="display: flex;" height="18rem" background="neutral-moderate">
+			<HStack gap="space-8" wrap={false}>
+				<VStack justify="center" gap="space-4">
+					<Placeholder text="center" />
+					<Placeholder />
+					<Placeholder />
+				</VStack>
+				<VStack justify="end" gap="space-4">
+					<Placeholder text="end" />
+					<Placeholder />
+					<Placeholder />
+				</VStack>
+				<VStack justify="start" gap="space-4">
+					<Placeholder text="start" />
+					<Placeholder />
+					<Placeholder />
+				</VStack>
+				<VStack justify="space-around">
+					<Placeholder text="around" />
+					<Placeholder />
+					<Placeholder />
+				</VStack>
+				<VStack justify="space-between">
+					<Placeholder text="between" />
+					<Placeholder />
+					<Placeholder />
+				</VStack>
+				<VStack justify="space-evenly">
+					<Placeholder text="evenly" />
+					<Placeholder />
+					<Placeholder />
+				</VStack>
+			</HStack>
+		</Box>
+	</Story>
+
+	<Story name="Responsive gap" locked>
+		<VStack
+			gap={{
+				xs: "space-8",
+				sm: "space-24",
+				md: "space-40",
+				lg: "space-56",
+				xl: "space-72",
+			}}
+		>
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+			<Placeholder height="3rem" width="3rem" />
+		</VStack>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/typography/ErrorMessage/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/typography/ErrorMessage/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import doc from "$lib/components/typography/ErrorMessage/ErrorMessage.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { ErrorMessage, VStack } from "$lib";
+</script>
+
+<Doc {doc} preview={{ width: "60%" }}>
+	<Story>
+		<ErrorMessage>You must fill in the text field before submitting.</ErrorMessage>
+	</Story>
+
+	<Story name="Sizes">
+		{@const exampleText = "You must fill in the text field before submitting."}
+		<VStack gap="space-20">
+			<ErrorMessage>Medium (18px): {exampleText}</ErrorMessage>
+			<ErrorMessage size="small">Small (16px): {exampleText}</ErrorMessage>
+		</VStack>
+	</Story>
+
+	<Story name="Show icon">
+		{@const exampleText = "You must fill in the text field before submitting."}
+		<VStack gap="space-20">
+			<ErrorMessage showIcon>{exampleText}</ErrorMessage>
+			<ErrorMessage showIcon size="small">{exampleText}</ErrorMessage>
+		</VStack>
+	</Story>
+
+	<Story name="Spacing">
+		<ErrorMessage spacing>Error message with spacing below</ErrorMessage>
+		<ErrorMessage>Next error message</ErrorMessage>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/typography/Heading/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/typography/Heading/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import doc from "$lib/components/typography/Heading/Heading.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { BodyLong, Heading, VStack } from "$lib";
+</script>
+
+<Doc {doc} preview={{ width: "60%" }}>
+	<Story>
+		<Heading size="large">This is a heading</Heading>
+	</Story>
+
+	<Story name="Sizes">
+		<VStack gap="space-16">
+			<Heading size="xlarge">This is a heading in xlarge (Desktop: 40px, Mobile: 32px)</Heading>
+			<Heading size="large">This is a heading in large (Desktop: 32px, Mobile: 28px)</Heading>
+			<Heading size="medium">This is a heading in medium (24px)</Heading>
+			<Heading size="small">This is a heading in small (20px)</Heading>
+			<Heading size="xsmall">This is a heading in xsmall (18px)</Heading>
+		</VStack>
+	</Story>
+
+	<Story name="Spacing">
+		<div>
+			<Heading size="medium" spacing>Minimum amount to apply</Heading>
+			<BodyLong>Expenses must be over 1,880 kroner to be eligible.</BodyLong>
+		</div>
+	</Story>
+
+	<Story name="Level">
+		<Heading as="h3" size="medium">This is an &lt;h3&gt;</Heading>
+	</Story>
+
+	<Story name="Override tag">
+		<Heading size="medium" as="span">This is now a span!</Heading>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/typography/Label/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/typography/Label/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import doc from "$lib/components/typography/Label/Label.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { Label, VStack } from "$lib";
+</script>
+
+<Doc {doc} preview={{ width: "60%" }}>
+	<Story>
+		<Label>Please provide the reason you waited more than 6 months to apply for reimbursement</Label
+		>
+	</Story>
+
+	<Story name="Sizes">
+		{@const exampleText =
+			"Please provide the reason you waited more than 6 months to apply for reimbursement"}
+		<VStack gap="space-20">
+			<Label>Medium (18px): {exampleText}</Label>
+			<Label size="small">Small (16px): {exampleText}</Label>
+		</VStack>
+	</Story>
+
+	<Story name="Spacing">
+		<Label spacing>Label with spacing below</Label>
+		<Label>Next label</Label>
+	</Story>
+
+	<Story name="Override tag">
+		<Label as="span">This is now a span!</Label>
+	</Story>
+
+	<Story name="Visually hidden">
+		<Label visuallyHidden>This label is only available to screen readers</Label>
+		<span>(The label above is only visible to screen readers.)</span>
+	</Story>
+</Doc>

--- a/packages/ds-svelte-community/src/routes/typography/Link/+page.svelte
+++ b/packages/ds-svelte-community/src/routes/typography/Link/+page.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import doc from "$lib/components/typography/Link/Link.svelte?doc";
+
+	import Doc from "$doclib/Doc.svelte";
+	import Story from "$doclib/Story.svelte";
+	import { BodyLong, Box, Link, VStack } from "$lib";
+	import PlusCircleFillIcon from "$lib/icons/PlusCircleFillIcon.svelte";
+	import PrinterSmallIcon from "$lib/icons/PrinterSmallIcon.svelte";
+</script>
+
+<Doc {doc} preview={{ width: "60%" }}>
+	<Story>
+		<BodyLong>
+			Officia incididunt <Link href="#example">link to a new page</Link> occaecat commodo id ad aliquip.
+		</BodyLong>
+	</Story>
+
+	<Story name="Variants">
+		<VStack gap="space-16">
+			<Link href="#example" variant="action">Action link</Link>
+			<Link href="#example" variant="neutral">Neutral link</Link>
+			<Link href="#example" variant="subtle">Subtle link</Link>
+		</VStack>
+	</Story>
+
+	<Story name="Underline">
+		<VStack gap="space-16">
+			<Link href="#example" underline={false}>Underline only on hover</Link>
+			<Link href="#example" underline>Always underlined</Link>
+		</VStack>
+	</Story>
+
+	<Story name="With icon">
+		<BodyLong>
+			Officia incididunt
+			<Link href="#example">
+				link to a new page
+				<PrinterSmallIcon title="Print document" />
+			</Link>
+			occaecat commodo id ad aliquip.
+		</BodyLong>
+	</Story>
+
+	<Story name="Inline">
+		<BodyLong>
+			Officia incididunt Culpa sit aute est duis minim in in voluptate velit Incididunt laborum nisi
+			nisi Lorem officia adipisicing non veniam culpa sit aute est duis
+			<Link inlineText href="#example">
+				this is a fairly long link that wraps to multiple lines when needed
+				<PlusCircleFillIcon aria-hidden="true" />
+			</Link>
+			minim in in voluptate velit Incididunt laborum nisi nisi Lorem officia adipisicing non veniam occaecat
+			commodo id ad aliquip.
+		</BodyLong>
+	</Story>
+
+	<Story name="Anchor">
+		<Box id="top" paddingBlock="space-16">
+			<Link href="#anchor">Jump to anchor</Link>
+			<BodyLong id="anchor" style="margin: 1600px 0;">
+				Lorem ipsum dolor sit amet consectetur, adipisicing elit. Minus quae iure nihil. Voluptatem
+				enim ratione sit consequuntur ab quibusdam rem dicta amet dolorum asperiores. Voluptates,
+				similique. Laborum deleniti nemo unde!
+				<br />
+				<Link href="#top">Jump to top</Link>
+			</BodyLong>
+		</Box>
+	</Story>
+</Doc>


### PR DESCRIPTION
… typography

Adds documentation pages mirroring Aksel examples (in English) for Fieldset, Theme, HGrid, Page, Hide, Show, Stack, HStack, VStack, Heading, Label, ErrorMessage, and Link.